### PR TITLE
sdk-integration: fix private key command

### DIFF
--- a/tests/sdk_tests/run-tests.sh
+++ b/tests/sdk_tests/run-tests.sh
@@ -3,7 +3,7 @@ if [ -n "$CERC_SCRIPT_DEBUG" ]; then
     set -x
 fi
 # Get the key from laconicd
-laconicd_key=$( docker compose exec laconicd echo y | laconicd keys export mykey --unarmored-hex --unsafe )
+laconicd_key=$( docker compose exec laconicd echo y | docker compose exec laconicd laconicd keys export mykey --unarmored-hex --unsafe )
 # Set parameters for the test suite
 cosmos_chain_id=laconic_9000-1
 laconicd_rest_endpoint=http://laconicd:1317


### PR DESCRIPTION
## Description
Fix: the previous command was exporting the wrong private key. Hence, the account not found error.

______

For contributor use:

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added  relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer

______

For admin use:

- [ ] Added appropriate labels to PR (ex. `WIP`, `R4R`, `docs`, etc)
- [ ] Reviewers assigned
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
